### PR TITLE
 Add Markdown to HTML converter script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+./outputs

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-./outputs
+outputs/*

--- a/python/md_to_html.py
+++ b/python/md_to_html.py
@@ -1,0 +1,46 @@
+import markdown
+import argparse
+def convert_md_to_html(md_file_path, output_file_path):
+    """
+    Convert a Markdown file to an HTML file.
+
+    Parameters:
+    md_file_path (str): The path to the input Markdown file.
+    output_file_path (str): The path where the output HTML file will be saved.
+
+    The function reads the Markdown content from the specified file, converts it to HTML,
+    and writes the resulting HTML to the output file with Bootstrap styling.
+    """
+    with open(md_file_path, 'r') as md_file:
+        md_content = md_file.read()
+        html_content = markdown.markdown(md_content)
+        html_output = f"""
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Markdown to HTML Script</title>
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    </head>
+    <body>
+        <div class="container mt-5">
+            <div class="content">
+                {html_content}
+            </div>
+        </div>
+        <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    </body>
+    </html>
+    """    
+    with open(output_file_path, 'w') as output_file:
+        output_file.write(html_output)
+    print(f"Converted {md_file_path} to {output_file_path}")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Convert Markdown file to HTML.')
+    parser.add_argument('md_file_path', type=str, help='Path to the input Markdown file')
+    parser.add_argument('output_file_path', type=str, help='Path to the output HTML file')
+    args = parser.parse_args()
+    convert_md_to_html(args.md_file_path, args.output_file_path)


### PR DESCRIPTION
This PR introduces a new **Python** script that converts Markdown files to HTML with `Bootstrap` styling. The script uses the `argparse` module for flexible command-line input and outputs a fully responsive HTML file.
## Tasks :
- [x] Markdown file to HTML File conversion
- [x] HTML files with Bootstrap styling
- [x] Supports CLI arguments
---
![image](https://github.com/user-attachments/assets/90ae4c59-cd5c-4331-b75a-7428ecc4fcaa)
![image](https://github.com/user-attachments/assets/c5692994-8b3e-482f-bed3-e241ed936ced)
